### PR TITLE
Add an iframe embedding example that use JWT auth

### DIFF
--- a/qlik.dev/tutorials/platform-operations/sdk-python/README.md
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/README.md
@@ -55,7 +55,20 @@ pip install -r requirements.txt
       --jwt-public-key ./publickey.cer
     ```
 
-* Create, configure, and deploy content to a tenant - combines multiple examples into a single end to end execution, example usage:
+* Embed a Qlik Sense application in an iFrame and access using JWT authentication, example usage:
+    ```bash
+    python ./tenant_embed_content.py \
+      --client-id <CLIENT_ID> \
+      --client-secret <CLIENT_SECRET> \
+      --target-tenant-hostname <HOSTNAME> \
+      --target-published-app-id "<APP_ID>" \
+      --jwt-issuer <ISSUER> \
+      --jwt-key-id <KEY_ID> \
+      --jwt-private-key ./privatekey.pem \ 
+      --jwt-public-key ./publickey.cer
+    ```
+
+* Create, configure, deploy, and embed content in a new tenant - combines multiple examples into a single end to end execution, example usage:
     ```bash
     python tenant_end_to_end.py \
       --client-id <CLIENT_ID> \

--- a/qlik.dev/tutorials/platform-operations/sdk-python/README.md
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/README.md
@@ -55,7 +55,7 @@ pip install -r requirements.txt
       --jwt-public-key ./publickey.cer
     ```
 
-* Embed a Qlik Sense application in an iFrame and access using JWT authentication, example usage:
+* Embed a Qlik Sense application in an iFrame and access using JWT authentication. This example uses the HTML from [this]([here](https://qlik.dev/tutorials/embed-content-using-iframes-and-anonymous-access#step-3---configure-web-page-variables)) section of the [Embed content using iframes and anonymous access](https://qlik.dev/tutorials/embed-content-using-iframes-and-anonymous-access) tutorial (the Javascript variables are substituted using Jinja). Example usage:
     ```bash
     python ./tenant_embed_content.py \
       --client-id <CLIENT_ID> \

--- a/qlik.dev/tutorials/platform-operations/sdk-python/constants.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/constants.py
@@ -4,3 +4,5 @@ GROUP_ANALYTICS_CONSUMER = "AnalyticConsumers"
 
 SPACE_MANAGED_PROD = "platform-ops-example-managed"
 SPACE_SHARED_DEV = "platform-ops-example-shared"
+
+LOCAL_WEB_SERVER_ADDRESS = "https://localhost:4443"

--- a/qlik.dev/tutorials/platform-operations/sdk-python/index.jinja
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/index.jinja
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="https://unpkg.com/enigma.js/enigma.min.js"></script>
+</head>
+
+<body>
+
+<div id="main">
+    <iframe id='qlik_frame' style='border:none;width:100%;height:900px;'></iframe>
+</div>
+
+<script>
+
+        //    CONFIGURATION
+
+        const TENANT = '{{ TENANT_HOSTNAME }}';
+        const JWTENDPOINT = '{{ JWT_URL }}';
+        const WEBINTEGRATIONID = '{{ WEB_INTEGRATION_ID }}';
+        const APPID = '{{ APP_ID }}';
+        const SHEETID = '{{ SHEET_ID }}';
+
+        //    MAIN
+
+        (async function main() {
+            const isLoggedIn = await qlikLogin();
+            const qcsHeaders = await getQCSHeaders();
+            const [session, enigmaApp] = await connectEnigma(qcsHeaders, APPID);
+            handleDisconnect(session);
+            const theme = await getTheme(enigmaApp);
+            renderSingleIframe('qlik_frame', APPID, SHEETID, theme);
+        })();
+
+        //    LOGIN
+
+        async function qlikLogin() {
+            const loggedIn = await checkLoggedIn();
+            if (loggedIn.status !== 200) {
+                const tokenRes = await (await getJWTToken(JWTENDPOINT)).json();
+                const loginRes = await jwtLogin(tokenRes.body);
+                if (loginRes.status != 200) {
+                    const message = 'Something went wrong while logging in.';
+                    alert(message);
+                    throw new Error(message);
+                }
+                const recheckLoggedIn = await checkLoggedIn();
+                if (recheckLoggedIn.status !== 200) {
+                    const message = 'Third-party cookies are not enabled in your browser settings and/or browser mode.';
+                    alert(message);
+                    throw new Error(message);
+                }
+            }
+            console.log('Logged in!');
+            return true;
+        }
+
+        async function checkLoggedIn() {
+            return await fetch(`https://${TENANT}/api/v1/users/me`, {
+                mode: 'cors',
+                credentials: 'include',
+                headers: {
+                    'qlik-web-integration-id': WEBINTEGRATIONID
+                },
+            })
+        }
+
+        async function getJWTToken(jwtEndpoint) {
+            return await fetch(jwtEndpoint, {
+                mode: 'cors',
+                method: 'GET'
+            })
+        }
+
+        async function jwtLogin(token) {
+            const authHeader = `Bearer ${token}`;
+            return await fetch(`https://${TENANT}/login/jwt-session?qlik-web-integration-id=${WEBINTEGRATIONID}`, {
+                credentials: 'include',
+                mode: 'cors',
+                method: 'POST',
+                headers: {
+                    'Authorization': authHeader,
+                    'qlik-web-integration-id': WEBINTEGRATIONID
+                },
+            })
+        }
+
+        async function getQCSHeaders() {
+            const response = await fetch(`https://${TENANT}/api/v1/csrf-token`, {
+                mode: 'cors',
+                credentials: 'include',
+                headers: {
+                    'qlik-web-integration-id': WEBINTEGRATIONID
+                },
+            })
+
+            const csrfToken = new Map(response.headers).get('qlik-csrf-token');
+            return {
+                'qlik-web-integration-id': WEBINTEGRATIONID,
+                'qlik-csrf-token': csrfToken,
+            };
+        }
+
+
+        //    ENIGMA ENGINE CONNECTION
+
+        async function connectEnigma(qcsHeaders, appId) {
+            const [session, app] = await getEnigmaSessionAndApp(qcsHeaders, appId);
+            return [session, app];
+        }
+
+        async function getEnigmaSessionAndApp(headers, appId) {
+            const params = Object.keys(headers)
+                .map((key) => `${key}=${headers[key]}`)
+                .join('&');
+
+            return (async () => {
+                const schema = await (await fetch('https://unpkg.com/enigma.js@2.7.0/schemas/12.612.0.json')).json();
+
+                try {
+                    return await createEnigmaAppSession(schema, appId, params);
+                }
+                catch {
+                    // If the socket is closed immediately following the connection this
+                    // could be due to an edge-case race condition where the newly created
+                    // user does not yet have access to the app due to access control propagation.
+                    // This bit of code will make another attempt after a 1.5 seconds.
+                    const waitSecond = await new Promise(resolve => setTimeout(resolve, 1500));
+                    try {
+                        return await createEnigmaAppSession(schema, appId, params);
+                    }
+                    catch (e) {
+                        throw new Error(e);
+                    }
+                }
+            })();
+        }
+
+        async function createEnigmaAppSession(schema, appId, params) {
+            const session = enigma.create({
+                schema,
+                url: `wss://${TENANT}/app/${appId}?${params}`
+            });
+            const enigmaGlobal = await session.open();
+            const enigmaApp = await enigmaGlobal.openDoc(appId);
+            return [session, enigmaApp];
+        }
+
+        //    BONUS! DYNAMICALLY FETCH THEME
+
+        async function getTheme(enigmaApp) {
+            const createAppProps = await enigmaApp.createSessionObject({
+                qInfo: {
+                    qId: "AppPropsList",
+                    qType: "AppPropsList"
+                },
+                qAppObjectListDef: {
+                    qType: "appprops",
+                    qData: {
+                        theme: "/theme"
+                    }
+                }
+            });
+            const appProps = await enigmaApp.getObject('AppPropsList');
+            const appPropsLayout = await appProps.getLayout();
+            const theme = appPropsLayout.qAppObjectList.qItems[0].qData.theme;
+            return theme;
+        }
+
+        //    HANDLE ENGINE SESSION CLOSURE
+
+        function handleDisconnect(session) {
+            session.on('closed', () => {
+                const message = 'Due to inactivity or loss of connection, this session has ended.';
+                console.log(message);
+            });
+
+            session.on('suspended', () => {
+                const message = 'Due to loss of connection, this session has been suspended.';
+                console.log(message);
+            });
+
+            window.addEventListener('offline', () => {
+                session.close();
+            });
+        }
+
+        //    HELPER FUNCTION TO GENERATE IFRAME
+
+        function renderSingleIframe(frameId, appId, sheetId, theme) {
+            const frameUrl = `https://${TENANT}/single/?appid=${appId}&sheet=${sheetId}&theme=${theme}&opt=ctxmenu,currsel`;
+            document.getElementById(frameId).setAttribute('src', frameUrl);
+        }
+
+
+    </script>
+
+</body>
+
+</html>

--- a/qlik.dev/tutorials/platform-operations/sdk-python/jwt_auth.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/jwt_auth.py
@@ -58,7 +58,7 @@ class JwtAuth:
                  email="jwt_test_user_1@jwt.io", email_verified=True, groups=("jwt_test_group_1", "jwt_test_group_2"),
                  expires_in=60):
         self.host = host.strip("/")
-        self.jwt_idp_config = jwt_idp_config
+        self.config = jwt_idp_config
         self.subject = subject
         self.name = name
         self.email = email
@@ -72,39 +72,42 @@ class JwtAuth:
 
         return response
 
-    def _get_session(self):
+    def generate_token(self):
         current_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        claims = {
+            "sub": self.subject,
+            "nbf": current_time,
+            "iat": current_time,
+            "jti": str(uuid.uuid4()),
+            "name": self.name,
+            "email": self.email,
+            "email_verified": self.email_verified,
+            "iss": self.config.issuer,
+            "exp": current_time + datetime.timedelta(seconds=self.expires_in),
+            "aud": "qlik.api/login/jwt-session",
+        }
+
+        if self.groups:
+            claims["groups"] = self.groups
+
+        private_key = open(self.config.private_key_file_path, "rb").read()
+        return jwt.encode(claims,
+                          private_key,
+                          algorithm="RS256",
+                          headers={"alg": "RS256",
+                                   "kid": self.config.key_id,
+                                   "typ": "JWT"})
+
+    def _get_session(self):
         if not self.session:
-            claims = {
-                "sub": self.subject,
-                "nbf": current_time,
-                "iat": current_time,
-                "jti": str(uuid.uuid4()),
-                "name": self.name,
-                "email": self.email,
-                "email_verified": self.email_verified,
-                "iss": self.jwt_idp_config.issuer,
-                "exp": current_time + datetime.timedelta(seconds=self.expires_in),
-                "aud": "qlik.api/login/jwt-session",
-            }
-
-            if self.groups:
-                claims["groups"] = self.groups
-
-            private_key = open(self.jwt_idp_config.private_key_file_path, "rb").read()
-            token = jwt.encode(claims,
-                               private_key,
-                               algorithm="RS256",
-                               headers={"alg": "RS256",
-                                        "kid": self.jwt_idp_config.key_id,
-                                        "typ": "JWT"})
+            token = self.generate_token()
             session = requests.Session()
             session.headers.update({"Authorization": "Bearer " + token})
             response = session.post(f"{self.host}/login/jwt-session")
             try:
                 response.raise_for_status()
             except Exception:
-                logger.error(f"JWT session failed: {response.text}\n{claims}")
+                logger.exception(f"JWT session failed: {response.text}")
                 raise
             else:
                 self.session = session

--- a/qlik.dev/tutorials/platform-operations/sdk-python/requirements.txt
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/requirements.txt
@@ -19,3 +19,5 @@ s3transfer==0.3.1
 soupsieve==1.9.5
 urllib3==1.26.9
 websocket-client==1.3.2
+jinja2==3.1.2
+

--- a/qlik.dev/tutorials/platform-operations/sdk-python/tenant_deploy_content.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/tenant_deploy_content.py
@@ -36,7 +36,7 @@ def verify_bot_access_to_source_app(sdk_client, app_id):
         logger.info(f"Retrieved the space with ID '{space.id}' from tenant '{sdk_client.config.host}'.")
 
         if space.type != "shared":
-            logger.error(f"The source app with ID '{app_id}' is in a managed space, it must be in a shared or personal space on '{sdk_client.config.host}'.")
+            logger.error(f"The source app with ID '{app_id}' is in a managed space, it must be in a shared or personal space in tenant '{sdk_client.config.host}'.")
             exit(1)
 
         roles = ["producer"]

--- a/qlik.dev/tutorials/platform-operations/sdk-python/tenant_deploy_content.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/tenant_deploy_content.py
@@ -177,6 +177,8 @@ def run(source_tenant_sdk_client, source_app_id, target_tenant_sdk_client, targe
     logging.info(
         f"Deployed and published an app from '{source_tenant_sdk_client.config.host}' to '{target_tenant_sdk_client.config.host}'.")
 
+    return published_app.attributes.id
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -192,7 +194,7 @@ if __name__ == "__main__":
 
     target_tenant_group = parser.add_argument_group("Target Tenant Information")
     target_tenant_group.add_argument("--target-tenant-hostname", required=True,
-                                     help="The hostname of the target tenant to configure, for example: tenant.region.qlikcloud.com")
+                                     help="The hostname of the target tenant to deploy content to, for example: tenant.region.qlikcloud.com")
     target_tenant_group.add_argument("--target-shared-space-id", required=True, help="increase output verbosity")
     target_tenant_group.add_argument("--target-managed-space-id", required=True, help="increase output verbosity")
 

--- a/qlik.dev/tutorials/platform-operations/sdk-python/tenant_embed_content.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/tenant_embed_content.py
@@ -69,6 +69,10 @@ def get_random_sheet_id(sdk_client, app_id):
         })
         sheet_list_layout = session_obj.get_layout()
         sheet_id_list = [q.qInfo.qId for q in sheet_list_layout.qAppObjectList.qItems]
+        if len(sheet_id_list) == 0:
+            logger.error(f"There are no public sheets in the app with ID '{app_id}' on tenant '{sdk_client.config.host}'.")
+            exit(1)
+
         random_sheet_id = sheet_id_list[random.randint(0, len(sheet_id_list) - 1)]
 
         logger.info(

--- a/qlik.dev/tutorials/platform-operations/sdk-python/tenant_embed_content.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/tenant_embed_content.py
@@ -173,10 +173,13 @@ def run(jwt_auth, sdk_client, published_app_id, published_app_sheet_id=None):
 
     logger.info(
         f"Starting web server using embedded sheet with ID '{published_app_sheet_id}' from app with ID '{published_app_id}' from tenant '{jwt_auth.host}'.")
+
+    print()
+    print(f"To view the embedded content open this URL in your browser: {constants.LOCAL_WEB_SERVER_ADDRESS}")
+    print()
     logger.warning(
         "If you're using Chrome you'll need to enable self signed certificates, see https://communicode.io/allow-https-localhost-chrome/. For other browsers, YMMV...")
 
-    logger.info(f"Serving local content from {constants.LOCAL_WEB_SERVER_ADDRESS}")
     httpd.serve_forever()
 
 

--- a/qlik.dev/tutorials/platform-operations/sdk-python/tenant_embed_content.py
+++ b/qlik.dev/tutorials/platform-operations/sdk-python/tenant_embed_content.py
@@ -1,0 +1,234 @@
+import argparse
+import http.server
+import json
+import logging
+import random
+import ssl
+from urllib.parse import urlparse
+
+from argparse_logging import add_log_level_argument
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+import constants
+import qlik_sdk_helper
+from jwt_auth import JwtAuth, JwtIdpConfig
+
+logger = logging.getLogger(__name__)
+
+
+class CORSHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    jwt_auth = None
+    index_html_page = None
+
+    def end_headers(self):
+        # Include additional response headers here. CORS for example:
+        self.send_header('Access-Control-Allow-Origin', '*')
+        http.server.SimpleHTTPRequestHandler.end_headers(self)
+
+    def do_GET(self):
+        if self.path == '/jwt':
+            self.send_response(200)
+            self.send_header("Content-type", "Content-Type: application/json")
+            self.end_headers()
+            self.wfile.write(bytes(json.dumps({
+                "body": self.jwt_auth.generate_token()
+            }), "utf-8"))
+        else:
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(bytes(self.index_html_page, "utf-8"))
+
+
+def get_random_sheet_id(sdk_client, app_id):
+    # Open the app and pick a random sheet and return its ID
+    app = sdk_client.apps.get(app_id)
+    logger.info(f"Retrieved the app with ID '{app_id}' from tenant '{sdk_client.config.host}'.")
+
+    with app.open():
+        session_obj = app.create_session_object({
+            "qInfo": {
+                "qType": "SheetList",
+                "qId": ""
+            },
+            "qAppObjectListDef": {
+                "qData": {
+                    "title": "/qMetaDef/title",
+                    "labelExpression": "/labelExpression",
+                    "showCondition": "/showCondition",
+                    "description": "/qMetaDef/description",
+                    "descriptionExpression": "/qMetaDef/descriptionExpression",
+                    "thumbnail": "/qMetaDef/thumbnail",
+                    "cells": "/cells",
+                    "rank": "/rank",
+                    "columns": "/columns",
+                    "rows": "/rows"
+                },
+                "qType": "sheet"
+            }
+        })
+        sheet_list_layout = session_obj.get_layout()
+        sheet_id_list = [q.qInfo.qId for q in sheet_list_layout.qAppObjectList.qItems]
+        random_sheet_id = sheet_id_list[random.randint(0, len(sheet_id_list) - 1)]
+
+        logger.info(
+            f"Opened a web socket to the app '{app.attributes.name}' with ID '{app.attributes.id}' on tenant '{sdk_client.config.host}' and selected the sheet with ID '{random_sheet_id}' to embed.")
+
+        return random_sheet_id
+
+
+def create_web_integration(sdk_client):
+    # Check for an existing web integration with our origin
+    for existing_web_integration in json.loads(sdk_client.rest(path="/api/v1/web-integrations").text)['data']:
+        if constants.LOCAL_WEB_SERVER_ADDRESS in existing_web_integration['validOrigins']:
+            logger.info(
+                f"Using existing web integration '{existing_web_integration['name']}' with ID '{existing_web_integration['id']}' in tenant '{sdk_client.config.host}'.")
+
+            return existing_web_integration['id']
+
+    # No matching web integration exists, create a new one
+    web_integration = json.loads(sdk_client.rest(
+        path="/api/v1/web-integrations",
+        method="POST",
+        data={
+            "name": "platform-ops-example-web-integration",
+            "validOrigins": [constants.LOCAL_WEB_SERVER_ADDRESS]
+        }
+    ).text)
+
+    logger.info(
+        f"Created web integration '{web_integration['name']}' with ID '{web_integration['id']}' in tenant '{sdk_client.config.host}'.")
+
+    return web_integration['id']
+
+
+def create_content_security_policy(sdk_client):
+    # Check for an existing csp with our origin and access rules
+    for existing_csp in json.loads(sdk_client.rest(path="/api/v1/csp-origins").text)['data']:
+        if f"https://{existing_csp['origin']}" == constants.LOCAL_WEB_SERVER_ADDRESS and existing_csp['frameAncestors']:
+            logger.info(
+                f"Using existing content security '{existing_csp['name']}' with ID '{existing_csp['id']}' in tenant '{sdk_client.config.host}'.")
+
+            return
+
+    # No matching csp exists, create a new one
+    csp = json.loads(sdk_client.rest(
+        path="/api/v1/csp-origins",
+        method="POST",
+        data={
+            "name": "platform-ops-example-csp",
+            "origin": constants.LOCAL_WEB_SERVER_ADDRESS,
+            "imgSrc": False,
+            "fontSrc": False,
+            "childSrc": False,
+            "frameSrc": True,
+            "mediaSrc": False,
+            "styleSrc": False,
+            "objectSrc": False,
+            "scriptSrc": False,
+            "workerSrc": False,
+            "connectSrc": False,
+            "formAction": False,
+            "connectSrcWSS": False,
+            "frameAncestors": True
+        }
+    ).text)
+
+    logger.info(
+        f"Created content security policy {csp['name']} with ID '{csp['id']}' in tenant '{sdk_client.config.host}'.")
+
+
+def run(jwt_auth, sdk_client, published_app_id, published_app_sheet_id=None):
+    web_integration_id = create_web_integration(sdk_client)
+    create_content_security_policy(sdk_client)
+
+    if not published_app_sheet_id:
+        published_app_sheet_id = get_random_sheet_id(sdk_client, published_app_id)
+
+    jinja_env = Environment(
+        loader=FileSystemLoader("."),
+        autoescape=select_autoescape()
+    )
+
+    index_html_page = jinja_env.get_template("index.jinja").render(
+        TENANT_HOSTNAME=jwt_auth.host.replace("https://", ""),
+        JWT_URL=f"{constants.LOCAL_WEB_SERVER_ADDRESS}/jwt",
+        WEB_INTEGRATION_ID=web_integration_id,
+        APP_ID=published_app_id,
+        SHEET_ID=published_app_sheet_id)
+
+    web_server_address_parts = urlparse(constants.LOCAL_WEB_SERVER_ADDRESS)
+    web_server_address = (str(web_server_address_parts.hostname), int(web_server_address_parts.port))
+
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.check_hostname = False
+    ctx.load_cert_chain(certfile=jwt_auth.config.public_key_file_path, keyfile=jwt_auth.config.private_key_file_path)
+
+    handler = CORSHTTPRequestHandler
+    handler.jwt_auth = jwt_auth
+    handler.index_html_page = index_html_page
+
+    httpd = http.server.HTTPServer(web_server_address, handler)
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+
+    logger.info(
+        f"Starting web server using embedded sheet with ID '{published_app_sheet_id}' from app with ID '{published_app_id}' from tenant '{jwt_auth.host}'.")
+    logger.warning(
+        "If you're using Chrome you'll need to enable self signed certificates, see https://communicode.io/allow-https-localhost-chrome/. For other browsers, YMMV...")
+
+    logger.info(f"Serving local content from {constants.LOCAL_WEB_SERVER_ADDRESS}")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    add_log_level_argument(parser)
+    parser.add_argument("--client-id", required=True, help="The OAuth client ID.")
+    parser.add_argument("--client-secret", required=True, help="The OAuth client secret.")
+
+    target_tenant_group = parser.add_argument_group("Target Tenant Information")
+    target_tenant_group.add_argument("--target-tenant-hostname", required=True,
+                                     help="The hostname of the target tenant to embed, for example: tenant.region.qlikcloud.com")
+    target_tenant_group.add_argument("--target-published-app-id", required=True,
+                                     help="The ID of the published app from the target tenant to use when embedding.")
+    target_tenant_group.add_argument("--target-published-app-sheet-id", required=False, default=None,
+                                     help="The ID of the sheet in the published app to embed. If no sheet ID is provided a random one will be selected.")
+
+    jwt_group = parser.add_argument_group("Target JWT IdP Configuration")
+    jwt_group.add_argument("--jwt-issuer", required=True, help="The 'issuer' field to use in the JWT.")
+    jwt_group.add_argument("--jwt-key-id", required=True, help="The 'kid' field to use in the JWT.")
+    jwt_group.add_argument("--jwt-private-key", required=True, help="The path to the local private key file.")
+    jwt_group.add_argument("--jwt-public-key", required=True, help="The path to the local public key file.")
+
+    jwt_claims = parser.add_argument_group("JWT Claims")
+    jwt_claims.add_argument("--jwt-claim-subject", required=False, default="jwt_test_user",
+                            help="The 'subject' field to use in the JWT claim.")
+    jwt_claims.add_argument("--jwt-claim-name", required=False, default="JWT Test User",
+                            help="The 'name' field to use in the JWT claim.")
+    jwt_claims.add_argument("--jwt-claim-email", required=False, default="jwt_test_user@jwt.io",
+                            help="The 'email' field to use in the JWT claim.")
+    jwt_claims.add_argument("--jwt-claim-email_verified", required=False, default=True, type=bool,
+                            help="The 'email_verified' field to use in the JWT claim.")
+    jwt_claims.add_argument("--jwt-claim-groups", required=False, default=[constants.GROUP_ANALYTICS_CONSUMER],
+                            nargs='+',
+                            help="The 'groups' field to use in the JWT claim (multiple groups can be specified).")
+    jwt_claims.add_argument("--jwt-claim-expires_in", required=False, default=60, type=int,
+                            help="The 'expires_in' field to use in the JWT.")
+
+    args = parser.parse_args()
+    logging.basicConfig(level=args.log_level)
+
+    jwt_idp_config = JwtIdpConfig(args.jwt_issuer, args.jwt_key_id, args.jwt_private_key, args.jwt_public_key)
+    if not jwt_idp_config.validate():
+        parser.print_help()
+        exit(1)
+
+    jwt_auth = JwtAuth(f"https://{args.target_tenant_hostname}",
+                       jwt_idp_config, args.jwt_claim_subject, args.jwt_claim_name, args.jwt_claim_email,
+                       args.jwt_claim_email_verified,
+                       args.jwt_claim_groups, args.jwt_claim_expires_in)
+
+    target_tenant_sdk_client = qlik_sdk_helper.create_sdk_client(args.client_id, args.client_secret,
+                                                                 args.target_tenant_hostname)
+
+    run(jwt_auth, target_tenant_sdk_client, args.target_published_app_id, args.target_published_app_sheet_id)


### PR DESCRIPTION
This examples using the existing JWT configuration to start up a local webserver and embed a random sheet from the app published as part of the `tenant_deploy_content` scripts.

The embedding is based on [this example](https://qlik.dev/tutorials/embed-content-using-iframes-and-anonymous-access) from `qlik.dev`.